### PR TITLE
chore: bump CI actions to Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Authenticate with github package registry
         run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" > ~/.npmrc

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Authenticate with github package registry
         run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" > ~/.npmrc
@@ -37,7 +37,7 @@ jobs:
         run: npm run zip
 
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: access8math-web-template.zip

--- a/.github/workflows/publish-nodejs-package.yml
+++ b/.github/workflows/publish-nodejs-package.yml
@@ -9,8 +9,8 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: '16.x'
           registry-url: 'https://npm.pkg.github.com'


### PR DESCRIPTION
Address warning from GitHub: https://github.com/coseeing/Access8MathTemplate/actions/runs/26484161707

<img width="1408" height="354" alt="Screenshot 2026-06-03 at 15 19 50" src="https://github.com/user-attachments/assets/a7cb7010-e087-4031-bd01-be957fc1570a" />
