### PR TITLE
chore: bump seemark to v1.10.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.3.1",
       "license": "ISC",
       "dependencies": {
-        "@coseeing/see-mark": "^1.10.0"
+        "@coseeing/see-mark": "^1.10.2"
       },
       "devDependencies": {
         "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
@@ -2141,9 +2141,9 @@
       "integrity": "sha512-ukKWUI6oq3652DezIqAcQltY6+bj1gKPV0X/djmj3BmxpW5iEr1D1T+T2Ais3L/bxl/ebh35CDo9Y6XdFTJAUA=="
     },
     "node_modules/@coseeing/see-mark": {
-      "version": "1.10.1",
-      "resolved": "https://npm.pkg.github.com/download/@coseeing/see-mark/1.10.1/1246c71fc39dc1c8a51fb7a383bb3016c091ec0a",
-      "integrity": "sha512-zQ/Y9jEIzZD+hZRZd+RX/Qrh4LHHXpyfrh8HLJp/ChzhKXl1cMugqupEsSm8ZiBicOZaL/m8d+ONJKfUBE1ANw==",
+      "version": "1.10.2",
+      "resolved": "https://npm.pkg.github.com/download/@coseeing/see-mark/1.10.2/e67bb19c79c0fb5e61b6bf033c8fe8a4b318340e",
+      "integrity": "sha512-/xkz1W/CzjHji7GcF1dflbMRLFB+VjoD4QNXnjrtXgBrFs3VlWZBR6xS63Bot9YItfwFhzX/oow0rqnTHc6eIw==",
       "dependencies": {
         "@coseeing/nemeth2latex": "^0.2.0",
         "html-react-parser": "^5.2.5",
@@ -23919,9 +23919,9 @@
       "integrity": "sha512-ukKWUI6oq3652DezIqAcQltY6+bj1gKPV0X/djmj3BmxpW5iEr1D1T+T2Ais3L/bxl/ebh35CDo9Y6XdFTJAUA=="
     },
     "@coseeing/see-mark": {
-      "version": "1.10.1",
-      "resolved": "https://npm.pkg.github.com/download/@coseeing/see-mark/1.10.1/1246c71fc39dc1c8a51fb7a383bb3016c091ec0a",
-      "integrity": "sha512-zQ/Y9jEIzZD+hZRZd+RX/Qrh4LHHXpyfrh8HLJp/ChzhKXl1cMugqupEsSm8ZiBicOZaL/m8d+ONJKfUBE1ANw==",
+      "version": "1.10.2",
+      "resolved": "https://npm.pkg.github.com/download/@coseeing/see-mark/1.10.2/e67bb19c79c0fb5e61b6bf033c8fe8a4b318340e",
+      "integrity": "sha512-/xkz1W/CzjHji7GcF1dflbMRLFB+VjoD4QNXnjrtXgBrFs3VlWZBR6xS63Bot9YItfwFhzX/oow0rqnTHc6eIw==",
       "requires": {
         "@coseeing/nemeth2latex": "^0.2.0",
         "html-react-parser": "^5.2.5",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.3.1",
   "homepage": "./",
   "dependencies": {
-    "@coseeing/see-mark": "^1.10.1"
+    "@coseeing/see-mark": "^1.10.2"
   },
   "scripts": {
     "start": "craco start",


### PR DESCRIPTION
ref: https://github.com/coseeing/SeeMark/pull/40